### PR TITLE
Improve portfolio landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Portföy Yönetim Uygulaması</title>
+    <meta name="description" content="Kişisel yatırım portföyünüzü yönetmek için kullanabileceğiniz bir uygulama" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,13 +69,14 @@ const sections = [
 export default function App() {
   const theme     = useTheme();
   const isMobile  = useMediaQuery("(max-width:768px)");
-  const [tabIdx, setTabIdx] = useState(0);
+  const dashboardIndex = sections.findIndex(s => s.label === "Dashboard");
+  const [tabIdx, setTabIdx] = useState(dashboardIndex >= 0 ? dashboardIndex : 0);
   const [drawer,  setDrawer] = useState(false);
 
   /* seansı hatırla */
   useEffect(()=>{
-    const saved = Number(localStorage.getItem("activeTab"))||0;
-    if (saved < sections.length) setTabIdx(saved);
+    const saved = Number(localStorage.getItem("activeTab"));
+    if (saved >= 0 && saved < sections.length) setTabIdx(saved);
   },[]);
   useEffect(()=>localStorage.setItem("activeTab",tabIdx),[tabIdx]);
 
@@ -114,7 +115,7 @@ export default function App() {
         <AppBar position="static" color="default" elevation={1}>
           <Toolbar>
             <IconButton edge="start" onClick={()=>setDrawer(true)}><MenuIcon/></IconButton>
-            <Typography variant="h6">Portföy Yönetimi</Typography>
+            <Typography variant="h6">Portföy Yönetim Programı</Typography>
           </Toolbar>
         </AppBar>
       )}


### PR DESCRIPTION
## Summary
- update HTML metadata for portfolio application
- set Dashboard as default page and tweak header text

## Testing
- `npm run lint` *(fails: handleEdit is not defined in Portfolio.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_6888489e2030832a9a18595303967764